### PR TITLE
Add zkSync Era token addresses

### DIFF
--- a/docs/overview/contracts-integrations.md
+++ b/docs/overview/contracts-integrations.md
@@ -33,6 +33,8 @@ See [All Active Deployed Protocol Contracts](#all-active-deployed-protocol-contr
  &nbsp;           | rETH  | [0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8](https://arbiscan.io/token/0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8)             
  Optimism         | RPL   | [0xc81d1f0eb955b0c020e5d5b264e1ff72c14d1401](https://optimistic.etherscan.io/token/0xc81d1f0eb955b0c020e5d5b264e1ff72c14d1401) 
  &nbsp;           | rETH  | [0x9bcef72be871e61ed4fbbc7630889bee758eb81d](https://optimistic.etherscan.io/token/0x9bcef72be871e61ed4fbbc7630889bee758eb81d) 
+ zkSync Era       | RPL   | [0x1CF8553Da5a75C20cdC33532cb19Ef7E3bFFf5BC](https://explorer.zksync.io/address/0x1CF8553Da5a75C20cdC33532cb19Ef7E3bFFf5BC)    
+ &nbsp;           | rETH  | [0x32Fd44bB869620C0EF993754c8a00Be67C464806](https://explorer.zksync.io/address/0x32Fd44bB869620C0EF993754c8a00Be67C464806)    
  Polygon          | RPL   | [0x7205705771547cf79201111b4bd8aaf29467b9ec](https://polygonscan.com/token/0x7205705771547cf79201111b4bd8aaf29467b9ec)         
  &nbsp;           | rETH  | [0x0266F4F08D82372CF0FcbCCc0Ff74309089c74d1](https://polygonscan.com/token/0x0266F4F08D82372CF0FcbCCc0Ff74309089c74d1)         
  Goerli*          | RPL   | [0x5e932688e81a182e3de211db6544f98b8e4f89c7](https://goerli.etherscan.io/address/0x5e932688e81a182e3de211db6544f98b8e4f89c7)   


### PR DESCRIPTION
With the new announcement of rETH+RPL bridged to zkSync, I was looking to find the token addresses to verify them. I didn't find them in the Rocketpool documentation, but instead only on the [zkSync Era Tokenlist](https://explorer.zksync.io/tokenlist).

I added them into the documentation.

Feel free to merge/adapt/reject :smile: 

**Preview**

![image](https://github.com/rocket-pool/docs.rocketpool.net/assets/4527862/6470dc62-6d01-4931-a544-e99ef6c06573)
