### PR TITLE
Update FAQ to explain how to remove old data

### DIFF
--- a/docs/guides/node/faq.md
+++ b/docs/guides/node/faq.md
@@ -47,3 +47,12 @@ Your client should be synced in less than a minute.
 
 The reboot information is cached and only updates every few hours.
 Running `sudo apt update` will force an update.
+
+### I changed my Execution Layer (ETH1) and/or my Beacon Chain or Consensus Layer (ETH2). How do I clean out the old data?
+
+If you change clients, Rocketpool does not delete the old volumes. This data could be wasting significant disk space and you may want to remove it. To do so, you need to find the volumes. If you are using the default Rocketpool settings, the docker volumes are stored  at `/var/lib/docker/volumes/`. The execution layer is in `rocketpool_eth1clientdata/_data/*` and the consensus layer is in `rocketpool_eth2clientdata/_data/*`.
+
+To access these directories, you may need to sudo as root using `sudo -i`. Then you can delete a directory by calling 'rm -rf <directory>'. For example, if you wanted to delete all the geth data, you would call `rm -rf /var/lib/docker/volumes/rocketpool_eth1clientdata/_data/geth/`. 
+
+To exit as root, type `exit`.
+


### PR DESCRIPTION
Because Rocketpool doesn't clean up data if you change execution/consensus clients, this FAQ explains how to do it. 