### PR TITLE
QOL Update: Enable a Firewall

### DIFF
--- a/docs/guides/node/securing-your-node.md
+++ b/docs/guides/node/securing-your-node.md
@@ -559,15 +559,20 @@ sudo ufw allow "22/tcp" comment 'Allow SSH'
 Allow execution client (formerly referred to as ETH1):
 
 ```shell
-sudo ufw allow 30303/tcp comment 'Execution client port, standardized by Rocket Pool'
-sudo ufw allow 30303/udp comment 'Execution client port, standardized by Rocket Pool'
+sudo ufw allow 30303 comment 'Execution client port, standardized by Rocket Pool'
 ```
 
 Allow consensus client (formerly referred to as ETH2):
 
 ```shell
-sudo ufw allow 9001/tcp comment 'Consensus client port, standardized by Rocket Pool'
-sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket Pool'
+sudo ufw allow 9001 comment 'Consensus client port, standardized by Rocket Pool'
+```
+
+Allow execution checkpoint and consensus checkpoint (if previously confiugred)
+
+```shell
+sudo ufw allow out 8545 comment 'Allow outbound traffic for Execution Checkpoint'
+sudo ufw allow out 5052 comment 'Allow outbound traffic for Consensus Checkpoint'
 ```
 
 Finally, enable `ufw`:


### PR DESCRIPTION
* Add additional rules which correspond to the ports required to communicate with external Execution Checkpoints and Consensus Checkpoints. Currently, the `ufw` rules will prevent the node from communicating with these services (viewable under `rocketpool node status` where `Primary EC status:` and `Primary CC status:` will each throw `connection refused` errors)

* Eliminates redundant rules - by simply specifying the port number, you cover both `tcp` and `udp` by default