### PR TITLE
Update config-docker.md - correct eth1 port forwarding

### DIFF
--- a/docs/guides/node/config-docker.md
+++ b/docs/guides/node/config-docker.md
@@ -112,7 +112,7 @@ You can manually adjust some of its parameters at the end of this process, but t
 You can proceed to the next section.
 
 ::: warning NOTE
-**Open up the P2P port in your router's port forwarding setup**. Configure it to forward **port 9001** on both TCP and UDP to your machine's local IP address.
+**Open up the P2P port in your router's port forwarding setup**. Configure it to forward **port 30303** on both TCP and UDP to your machine's local IP address.
 This way, other Consensus clients can discover it and communicate with it from the outside. This will help your Consensus client sync quickly and improve performance (and thus rewards).
 
 Each router has a different way of doing this, so **you'll need to check out your router's manual on how to set up port forwarding**.


### PR DESCRIPTION
The guide recommends opening port 9001 twice: once under **Execution Client Setup**, and again under **Consensus Client Setup**. However, port 30303 was not mentioned for eth1 client to sync. I found it in the FAQ instead.

The pull request corrects that.