### PR TITLE
Update to smoothing pool rewards claim section

### DIFF
--- a/docs/guides/node/rewards.md
+++ b/docs/guides/node/rewards.md
@@ -59,8 +59,7 @@ Therefore it is **crucial** that you maintain at least 10% collateral at all tim
 ### Smoothing Pool ETH Rewards
 
 Along with RPL rewards, the Smoothing Pool's entire ETH balance is distributed during rewards checkpoints.
-Half of it (minus the average node commission) will be sent to the rETH contract where it can be burned for ETH from pool stakers that want to exit or used to create more minipools.
-The remaining portion will be distributed amongst the eligible node operators.
+The the percentage corresponding to pool stakers's share (50% for 16 ETH minipools, and 75% for LEB8s), minus the respective node commission (15% or 20% for 16 ETH minipools, and 14% of LEB8s), will be sent to the rETH contract where it can either 1) be burned for ETH from pool stakers that want to exit, or 2) be used to create more minipools. The remaining portion will be distributed amongst the eligible node operators.
 
 Nodes that are opted into the smoothing pool for the interval, even if only part of the time, are eligible for a portion of the Smoothing Pool's total balance.
 The balance is snapshotted at the rewards checkpoint, and the Oracle DAO determines each eligible node's portion.

--- a/docs/guides/node/rewards.md
+++ b/docs/guides/node/rewards.md
@@ -59,7 +59,7 @@ Therefore it is **crucial** that you maintain at least 10% collateral at all tim
 ### Smoothing Pool ETH Rewards
 
 Along with RPL rewards, the Smoothing Pool's entire ETH balance is distributed during rewards checkpoints.
-The percentage of Smoothing Pool rewards which corresponds to the pool stakers' ETH share (50% for 16 ETH minipools, or 75% for LEB8s), minus the respective node commission (15% or 20% for 16 ETH minipools, or 14% of LEB8s), will be sent to the rETH contract. There it can either 1) be burned for ETH from pool stakers that want to exit, or 2) be used to create more minipools. 
+Out of the entire Smoothing Pool's rewards balance, the percentage which corresponds to pool stakers (50% for 16 ETH minipools, or 75% for LEB8s), minus the respective node commission (15% or 20% for 16 ETH minipools, or 14% of LEB8s), will be sent to the rETH contract. There it can either 1) be burned for ETH from pool stakers that want to exit, or 2) be used to create more minipools. 
 The remaining portion will be distributed amongst the eligible node operators.
 
 Nodes that are opted into the smoothing pool for the interval, even if only part of the time, are eligible for a portion of the Smoothing Pool's total balance.

--- a/docs/guides/node/rewards.md
+++ b/docs/guides/node/rewards.md
@@ -59,7 +59,7 @@ Therefore it is **crucial** that you maintain at least 10% collateral at all tim
 ### Smoothing Pool ETH Rewards
 
 Along with RPL rewards, the Smoothing Pool's entire ETH balance is distributed during rewards checkpoints.
-The the percentage corresponding to pool stakers's share (50% for 16 ETH minipools, and 75% for LEB8s), minus the respective node commission (15% or 20% for 16 ETH minipools, and 14% of LEB8s), will be sent to the rETH contract where it can either 1) be burned for ETH from pool stakers that want to exit, or 2) be used to create more minipools. 
+The percentage of Smoothing Pool rewards which corresponds to the pool stakers' ETH share (50% for 16 ETH minipools, or 75% for LEB8s), minus the respective node commission (15% or 20% for 16 ETH minipools, or 14% of LEB8s), will be sent to the rETH contract. There it can either 1) be burned for ETH from pool stakers that want to exit, or 2) be used to create more minipools. 
 The remaining portion will be distributed amongst the eligible node operators.
 
 Nodes that are opted into the smoothing pool for the interval, even if only part of the time, are eligible for a portion of the Smoothing Pool's total balance.

--- a/docs/guides/node/rewards.md
+++ b/docs/guides/node/rewards.md
@@ -59,7 +59,7 @@ Therefore it is **crucial** that you maintain at least 10% collateral at all tim
 ### Smoothing Pool ETH Rewards
 
 Along with RPL rewards, the Smoothing Pool's entire ETH balance is distributed during rewards checkpoints.
-Out of the entire Smoothing Pool's rewards balance, the percentage which corresponds to pool stakers (50% for 16 ETH minipools, or 75% for LEB8s), minus the respective node commission (15% or 20% for 16 ETH minipools, or 14% of LEB8s), will be sent to the rETH contract. There it can either 1) be burned for ETH from pool stakers that want to exit, or 2) be used to create more minipools. 
+Out of the entire Smoothing Pool's rewards balance, the percentage which corresponds to pool stakers (50% for 16 ETH minipools, or 75% for LEB8s), minus the respective node commission (15% for 16 ETH minipools, or 14% of LEB8s), will be sent to the rETH contract. There it can either 1) be burned for ETH from pool stakers that want to exit, or 2) be used to create more minipools. 
 The remaining portion will be distributed amongst the eligible node operators.
 
 Nodes that are opted into the smoothing pool for the interval, even if only part of the time, are eligible for a portion of the Smoothing Pool's total balance.

--- a/docs/guides/node/rewards.md
+++ b/docs/guides/node/rewards.md
@@ -59,7 +59,7 @@ Therefore it is **crucial** that you maintain at least 10% collateral at all tim
 ### Smoothing Pool ETH Rewards
 
 Along with RPL rewards, the Smoothing Pool's entire ETH balance is distributed during rewards checkpoints.
-Out of the entire Smoothing Pool's rewards balance, the percentage which corresponds to pool stakers (50% for 16 ETH minipools, or 75% for LEB8s), minus the respective node commission (15% for 16 ETH minipools, or 14% of LEB8s), will be sent to the rETH contract. There it can either 1) be burned for ETH from pool stakers that want to exit, or 2) be used to create more minipools. 
+Out of the entire Smoothing Pool's rewards balance, the percentage which corresponds to pool stakers (50% for 16 ETH minipools, or 75% for LEB8s), minus the respective node commission (14-20% for 16 ETH minipools, or 14% of LEB8s), will be sent to the rETH contract. There it can either 1) be burned for ETH from pool stakers that want to exit, or 2) be used to create more minipools. 
 The remaining portion will be distributed amongst the eligible node operators.
 
 Nodes that are opted into the smoothing pool for the interval, even if only part of the time, are eligible for a portion of the Smoothing Pool's total balance.

--- a/docs/guides/node/rewards.md
+++ b/docs/guides/node/rewards.md
@@ -59,7 +59,7 @@ Therefore it is **crucial** that you maintain at least 10% collateral at all tim
 ### Smoothing Pool ETH Rewards
 
 Along with RPL rewards, the Smoothing Pool's entire ETH balance is distributed during rewards checkpoints.
-Out of the entire Smoothing Pool's rewards balance, the percentage which corresponds to pool stakers (50% for 16 ETH minipools, or 75% for LEB8s), minus the respective node commission (14-20% for 16 ETH minipools, or 14% of LEB8s), will be sent to the rETH contract. There it can either 1) be burned for ETH from pool stakers that want to exit, or 2) be used to create more minipools. 
+Out of the entire Smoothing Pool's rewards balance, the percentage which corresponds to pool stakers (50% for 16 ETH minipools, or 75% for LEB8s), minus the respective node commission, will be sent to the rETH contract. There it can either 1) be burned for ETH from pool stakers that want to exit, or 2) be used to create more minipools. 
 The remaining portion will be distributed amongst the eligible node operators.
 
 Nodes that are opted into the smoothing pool for the interval, even if only part of the time, are eligible for a portion of the Smoothing Pool's total balance.

--- a/docs/guides/node/rewards.md
+++ b/docs/guides/node/rewards.md
@@ -59,7 +59,8 @@ Therefore it is **crucial** that you maintain at least 10% collateral at all tim
 ### Smoothing Pool ETH Rewards
 
 Along with RPL rewards, the Smoothing Pool's entire ETH balance is distributed during rewards checkpoints.
-The the percentage corresponding to pool stakers's share (50% for 16 ETH minipools, and 75% for LEB8s), minus the respective node commission (15% or 20% for 16 ETH minipools, and 14% of LEB8s), will be sent to the rETH contract where it can either 1) be burned for ETH from pool stakers that want to exit, or 2) be used to create more minipools. The remaining portion will be distributed amongst the eligible node operators.
+The the percentage corresponding to pool stakers's share (50% for 16 ETH minipools, and 75% for LEB8s), minus the respective node commission (15% or 20% for 16 ETH minipools, and 14% of LEB8s), will be sent to the rETH contract where it can either 1) be burned for ETH from pool stakers that want to exit, or 2) be used to create more minipools. 
+The remaining portion will be distributed amongst the eligible node operators.
 
 Nodes that are opted into the smoothing pool for the interval, even if only part of the time, are eligible for a portion of the Smoothing Pool's total balance.
 The balance is snapshotted at the rewards checkpoint, and the Oracle DAO determines each eligible node's portion.


### PR DESCRIPTION
Adjusted smoothing pool rewards claim section to consider as well LEB8s. This update is relevant post-Atlas with the introduction of LEB8s, since half of the smoothing pool rewards (minus node commission) is no longer what is sent to the rETH contract. 