### PR TITLE
Lighthouse Quic Protocol Support

### DIFF
--- a/docs/guides/node/securing-your-node.md
+++ b/docs/guides/node/securing-your-node.md
@@ -570,6 +570,12 @@ sudo ufw allow 9001/tcp comment 'Consensus client port, standardized by Rocket P
 sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket Pool'
 ```
 
+If you run lighthouse client v4.5.0+, you can use quic protocol to reduce latency / increase bandwitdh, quic protocol uses lighthouse's --port + 1 to listen for quic messages by default: https://lighthouse-blog.sigmaprime.io/Quic.html
+
+```shell
+sudo ufw allow 9002/udp comment 'Execution client port, standardized by Rocket Pool'
+```
+
 Finally, enable `ufw`:
 
 ```


### PR DESCRIPTION
https://lighthouse-blog.sigmaprime.io/Quic.html

as of lighthouse v4.5.0 (https://github.com/sigp/lighthouse/releases/tag/v4.5.0) lighthouse supports the quic protocol

quic uses udp over the traditional tcp connection, and is bench marking better in latency and bandwidth compared to traditional tcp connections 

to enable the feature: light house will listen on --port + 1 by default for quic messages, so you will need to enable the firewall / port forwarding to open port + 1 for udp connections