### PR TITLE
[DOC] Update securing-your-node.md

### DIFF
--- a/docs/guides/node/securing-your-node.md
+++ b/docs/guides/node/securing-your-node.md
@@ -576,10 +576,10 @@ sudo ufw allow 9001/tcp comment 'Consensus client port, standardized by Rocket P
 sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket Pool'
 ```
 
-If you run lighthouse client v4.5.0+, you can use quic protocol to reduce latency / increase bandwitdh, quic protocol uses lighthouse's --port + 1 to listen for quic messages by default: https://lighthouse-blog.sigmaprime.io/Quic.html
+If you run lighthouse client v4.5.0+, you can use quic protocol to reduce latency / increase bandwitdh, quic protocol uses lighthouse's --port + 1 to listen for quic messages by default: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html
 
 ```shell
-sudo ufw allow 9002/udp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 8001/udp comment 'Consensus client port, standardised by Rocket Pool'
 ```
 
 Finally, enable `ufw`:


### PR DESCRIPTION
Since smartnode v1.11.2, the QUIC port for Lighthouse has changed from `9002` to `8001` in Rocket Pool.
Link: https://discord.com/channels/405159462932971535/918351974406172723/1186523894815932486

Also, the link to QUIC's explanation from Ligthouse blog is brokend, I updated it as well.