### PR TITLE
Mark bloXroute Max Profit relay as censoring.

### DIFF
--- a/docs/guides/node/mev.md
+++ b/docs/guides/node/mev.md
@@ -51,7 +51,7 @@ Rocket Pool currently offers its node operators access to **multiple different r
 | Name                                                                                                         | Regulation                     | MEV Types                                  |
 | ------------------------------------------------------------------------------------------------------------ | ------------------------------ | ------------------------------------------ |
 | [Flashbots](https://boost.flashbots.net/)                                                                    | Complies with OFAC Sanctions\* | All types                                  |
-| [bloXroute Max Profit](https://docs.bloxroute.com/apis/mev-solution/mev-relay-for-validators)                | Unregulated                    | All types                                  |
+| [bloXroute Max Profit](https://docs.bloxroute.com/apis/mev-solution/mev-relay-for-validators)                | Complies with OFAC Sanctions\* | All types                                  |
 | [bloXroute Regulated](https://docs.bloxroute.com/apis/mev-solution/mev-relay-for-validators)                 | Complies with OFAC Sanctions\* | All types                                  |
 | [Eden Network](https://v2.docs.edennetwork.io/eden-relay/overview)                                           | Complies with OFAC Sanctions\* | All types                                  |
 | [Ultra Sound](https://relay.ultrasound.money/)                                                               | Unregulated                    | All types                                  |


### PR DESCRIPTION
See [the related PR in the SmartNode](https://github.com/rocket-pool/smartnode/pull/600) for explanations and also merge only if the SmartNode was adjusted and released.