### PR TITLE
fix: Corrects minor copywrite/rendering issues in glossary

### DIFF
--- a/docs/overview/glossary.mdx
+++ b/docs/overview/glossary.mdx
@@ -2,7 +2,7 @@
 
 You may stumble upon some unfamiliar concepts in the Rocket Pool documentation. This section lists the common terms in the documentation for easy access, learning and plugin/theme development.
 
-## APY - Annual Percent Yield (APY):
+## APY - Annual Percent Yield (APY)
 
 The amount of profit (yield) calculated over a one-year period divided by the initial investment amount expressed as a percentage.
 
@@ -109,6 +109,7 @@ A token that represents a regular user’s deposit into the staking pool. Users 
 ## RPL (Rocket Pool Token)
 
 **RPL — Rocket Pool Protocol Token**
+
 RPL is the primary protocol token that will be used in governance of the protocol and can also be staked on a Rocket Pool node.
 
 From a Node Operator perspective:


### PR DESCRIPTION
No other definition has a `:` and in the rendering of the 2nd it appears all on one line

Not sure how to resolve the bold not rendering in the docs but hope this one click merge pull request should be sufficient to resolve two of the three issues

See diff for more details