### PR TITLE
os.mdt - Recommend Ubuntu 24.04 LTS instead of 20.04 which is out of …

### DIFF
--- a/docs/guides/node/vps/os.mdx
+++ b/docs/guides/node/vps/os.mdx
@@ -25,7 +25,7 @@ Click the orange **Launch Instance** button and select **Launch Instance** from 
 You will be presented with a marketplace of Amazon Machine Images.
 Each of these represents a specific snapshot of a machine with a pre-installed Operating System and some other useful software components.
 
-For a Rocket Pool node, we recommend you use the **Ubuntu Server 20.04 LTS (HVM)** image.
+For a Rocket Pool node, we recommend you use the **Ubuntu Server 24.04 LTS (HVM)** image.
 
 Next, you will have to choose an **Instance Type**.
 This determines what virtual hardware resources your machine will have available.


### PR DESCRIPTION
I am proposing a small change in the documentation.

Support for 20.04 LTS will last until 31 May 2025, so it should not be recommended anymore for new setups.