### PR TITLE
prepare-pc.md - recommend Ubuntu 24.04 instead of 20.04 which is eol

### DIFF
--- a/docs/guides/node/local/prepare-pc.md
+++ b/docs/guides/node/local/prepare-pc.md
@@ -40,7 +40,7 @@ on [Ubuntu](https://ubuntu.com/about), [Debian](https://www.debian.org/intro/why
 and [Fedora](https://docs.fedoraproject.org/en-US/project/).
 
 ::: warning NOTE
-If you plan to use Ubuntu, we strongly recommend using an **LTS** release such as 20.04.
+If you plan to use Ubuntu, we strongly recommend using an **LTS** release such as 24.04.
 These releases are actively maintained for longer periods of time, which helps with the security and stability of your
 node.
 :::


### PR DESCRIPTION
I am proposing a small change in the documentation.

Support for 20.04 LTS will last until 31 May 2025, so it should not be recommended anymore for new setups.