### PR TITLE
Docs: correct spelling error

### DIFF
--- a/docs/de/node-staking/securing-your-node.mdx
+++ b/docs/de/node-staking/securing-your-node.mdx
@@ -584,7 +584,7 @@ sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket P
 Wenn Sie Lighthouse-Client v4.5.0+ ausführen, können Sie das QUIC-Protokoll verwenden, um die Latenz zu reduzieren / die Bandbreite zu erhöhen. Das QUIC-Protokoll verwendet standardmäßig den Port von Lighthouse + 1, um QUIC-Nachrichten zu empfangen: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html
 
 ```shell
-sudo ufw allow 8001/udp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 8001/udp comment 'Consensus client port, standardized by Rocket Pool'
 ```
 
 Aktivieren Sie schließlich `ufw`:

--- a/docs/en/node-staking/securing-your-node.mdx
+++ b/docs/en/node-staking/securing-your-node.mdx
@@ -584,7 +584,7 @@ sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket P
 If you run lighthouse client v4.5.0+, you can use quic protocol to reduce latency / increase bandwidth, quic protocol uses lighthouse's --port + 1 to listen for quic messages by default: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html
 
 ```shell
-sudo ufw allow 8001/udp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 8001/udp comment 'Consensus client port, standardized by Rocket Pool'
 ```
 
 Finally, enable `ufw`:

--- a/docs/es/node-staking/securing-your-node.mdx
+++ b/docs/es/node-staking/securing-your-node.mdx
@@ -584,7 +584,7 @@ sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket P
 Si ejecutas el cliente lighthouse v4.5.0+, puedes usar el protocolo quic para reducir latencia / aumentar ancho de banda, el protocolo quic usa --port + 1 de lighthouse para escuchar mensajes quic por defecto: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html
 
 ```shell
-sudo ufw allow 8001/udp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 8001/udp comment 'Consensus client port, standardized by Rocket Pool'
 ```
 
 Finalmente, habilita `ufw`:

--- a/docs/fr/node-staking/securing-your-node.mdx
+++ b/docs/fr/node-staking/securing-your-node.mdx
@@ -584,7 +584,7 @@ sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket P
 Si vous exécutez le client lighthouse v4.5.0+, vous pouvez utiliser le protocole quic pour réduire la latence / augmenter la bande passante, le protocole quic utilise le --port de lighthouse + 1 pour écouter les messages quic par défaut : https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html
 
 ```shell
-sudo ufw allow 8001/udp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 8001/udp comment 'Consensus client port, standardized by Rocket Pool'
 ```
 
 Enfin, activez `ufw` :

--- a/docs/it/node-staking/securing-your-node.mdx
+++ b/docs/it/node-staking/securing-your-node.mdx
@@ -584,7 +584,7 @@ sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket P
 Se esegui lighthouse client v4.5.0+, puoi usare il protocollo quic per ridurre la latenza / aumentare la larghezza di banda, il protocollo quic usa la --port di lighthouse + 1 per ascoltare i messaggi quic per impostazione predefinita: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html
 
 ```shell
-sudo ufw allow 8001/udp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 8001/udp comment 'Consensus client port, standardized by Rocket Pool'
 ```
 
 Infine, abilita `ufw`:

--- a/docs/ja/node-staking/securing-your-node.mdx
+++ b/docs/ja/node-staking/securing-your-node.mdx
@@ -584,7 +584,7 @@ sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket P
 lighthouse client v4.5.0+を実行している場合、quicプロトコルを使用してレイテンシを削減/帯域幅を増やすことができます。quicプロトコルはデフォルトでlighthouseの--port + 1を使用してquicメッセージをリッスンします: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html
 
 ```shell
-sudo ufw allow 8001/udp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 8001/udp comment 'Consensus client port, standardized by Rocket Pool'
 ```
 
 最後に、`ufw`を有効にします。

--- a/docs/ko/node-staking/securing-your-node.mdx
+++ b/docs/ko/node-staking/securing-your-node.mdx
@@ -584,7 +584,7 @@ sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket P
 lighthouse 클라이언트 v4.5.0+를 실행하는 경우 quic 프로토콜을 사용하여 지연 시간을 줄이고/대역폭을 늘릴 수 있으며, quic 프로토콜은 기본적으로 lighthouse의 --port + 1을 사용하여 quic 메시지를 수신합니다: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html
 
 ```shell
-sudo ufw allow 8001/udp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 8001/udp comment 'Consensus client port, standardized by Rocket Pool'
 ```
 
 마지막으로 `ufw`를 활성화하세요:

--- a/docs/pt/node-staking/securing-your-node.mdx
+++ b/docs/pt/node-staking/securing-your-node.mdx
@@ -584,7 +584,7 @@ sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket P
 Se você executar o cliente lighthouse v4.5.0+, você pode usar o protocolo quic para reduzir a latência / aumentar a largura de banda, o protocolo quic usa lighthouse's --port + 1 para escutar mensagens quic por padrão: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html
 
 ```shell
-sudo ufw allow 8001/udp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 8001/udp comment 'Consensus client port, standardized by Rocket Pool'
 ```
 
 Finalmente, habilite o `ufw`:

--- a/docs/ru/node-staking/securing-your-node.mdx
+++ b/docs/ru/node-staking/securing-your-node.mdx
@@ -584,7 +584,7 @@ sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket P
 Если вы используете клиент lighthouse v4.5.0+, вы можете использовать протокол quic для уменьшения задержки / увеличения пропускной способности, протокол quic использует --port lighthouse + 1 для прослушивания сообщений quic по умолчанию: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html
 
 ```shell
-sudo ufw allow 8001/udp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 8001/udp comment 'Consensus client port, standardized by Rocket Pool'
 ```
 
 Наконец, включите `ufw`:

--- a/docs/tr/node-staking/securing-your-node.mdx
+++ b/docs/tr/node-staking/securing-your-node.mdx
@@ -584,7 +584,7 @@ sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket P
 Lighthouse istemci v4.5.0+ çalıştırıyorsanız, gecikmeyi azaltmak / bant genişliğini artırmak için quic protokolünü kullanabilirsiniz, quic protokolü varsayılan olarak lighthouse'un --port + 1'ini quic mesajlarını dinlemek için kullanır: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html
 
 ```shell
-sudo ufw allow 8001/udp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 8001/udp comment 'Consensus client port, standardized by Rocket Pool'
 ```
 
 Son olarak, `ufw`'yi etkinleştirin:

--- a/docs/zh/node-staking/securing-your-node.mdx
+++ b/docs/zh/node-staking/securing-your-node.mdx
@@ -584,7 +584,7 @@ sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket P
 如果你运行 lighthouse 客户端 v4.5.0+，你可以使用 quic 协议来减少延迟/增加带宽，quic 协议默认使用 lighthouse 的 --port + 1 来监听 quic 消息：https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html
 
 ```shell
-sudo ufw allow 8001/udp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 8001/udp comment 'Consensus client port, standardized by Rocket Pool'
 ```
 
 最后，启用 `ufw`：


### PR DESCRIPTION
Correct the incorrect spelling of the word 'standardized' in the comment for the ufw firewall rules exception for Lighthouse, across all language documents.