### PR TITLE
Docs: correct spelling inconsistency

### DIFF
--- a/docs/de/node-staking/securing-your-node.mdx
+++ b/docs/de/node-staking/securing-your-node.mdx
@@ -570,15 +570,15 @@ sudo ufw allow "22/tcp" comment 'Allow SSH'
 Erlauben Sie Execution-Client (früher als ETH1 bezeichnet):
 
 ```shell
-sudo ufw allow 30303/tcp comment 'Execution client port, standardized by Rocket Pool'
-sudo ufw allow 30303/udp comment 'Execution client port, standardized by Rocket Pool'
+sudo ufw allow 30303/tcp comment 'Execution client port, standardised by Rocket Pool'
+sudo ufw allow 30303/udp comment 'Execution client port, standardised by Rocket Pool'
 ```
 
 Erlauben Sie Consensus-Client (früher als ETH2 bezeichnet):
 
 ```shell
-sudo ufw allow 9001/tcp comment 'Consensus client port, standardized by Rocket Pool'
-sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket Pool'
+sudo ufw allow 9001/tcp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 9001/udp comment 'Consensus client port, standardised by Rocket Pool'
 ```
 
 Wenn Sie Lighthouse-Client v4.5.0+ ausführen, können Sie das QUIC-Protokoll verwenden, um die Latenz zu reduzieren / die Bandbreite zu erhöhen. Das QUIC-Protokoll verwendet standardmäßig den Port von Lighthouse + 1, um QUIC-Nachrichten zu empfangen: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html

--- a/docs/en/node-staking/securing-your-node.mdx
+++ b/docs/en/node-staking/securing-your-node.mdx
@@ -570,15 +570,15 @@ sudo ufw allow "22/tcp" comment 'Allow SSH'
 Allow execution client (formerly referred to as ETH1):
 
 ```shell
-sudo ufw allow 30303/tcp comment 'Execution client port, standardized by Rocket Pool'
-sudo ufw allow 30303/udp comment 'Execution client port, standardized by Rocket Pool'
+sudo ufw allow 30303/tcp comment 'Execution client port, standardised by Rocket Pool'
+sudo ufw allow 30303/udp comment 'Execution client port, standardised by Rocket Pool'
 ```
 
 Allow consensus client (formerly referred to as ETH2):
 
 ```shell
-sudo ufw allow 9001/tcp comment 'Consensus client port, standardized by Rocket Pool'
-sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket Pool'
+sudo ufw allow 9001/tcp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 9001/udp comment 'Consensus client port, standardised by Rocket Pool'
 ```
 
 If you run lighthouse client v4.5.0+, you can use quic protocol to reduce latency / increase bandwidth, quic protocol uses lighthouse's --port + 1 to listen for quic messages by default: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html

--- a/docs/es/node-staking/securing-your-node.mdx
+++ b/docs/es/node-staking/securing-your-node.mdx
@@ -570,15 +570,15 @@ sudo ufw allow "22/tcp" comment 'Allow SSH'
 Permite el cliente de ejecución (antes llamado ETH1):
 
 ```shell
-sudo ufw allow 30303/tcp comment 'Execution client port, standardized by Rocket Pool'
-sudo ufw allow 30303/udp comment 'Execution client port, standardized by Rocket Pool'
+sudo ufw allow 30303/tcp comment 'Execution client port, standardised by Rocket Pool'
+sudo ufw allow 30303/udp comment 'Execution client port, standardised by Rocket Pool'
 ```
 
 Permite el cliente de consenso (antes llamado ETH2):
 
 ```shell
-sudo ufw allow 9001/tcp comment 'Consensus client port, standardized by Rocket Pool'
-sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket Pool'
+sudo ufw allow 9001/tcp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 9001/udp comment 'Consensus client port, standardised by Rocket Pool'
 ```
 
 Si ejecutas el cliente lighthouse v4.5.0+, puedes usar el protocolo quic para reducir latencia / aumentar ancho de banda, el protocolo quic usa --port + 1 de lighthouse para escuchar mensajes quic por defecto: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html

--- a/docs/fr/node-staking/securing-your-node.mdx
+++ b/docs/fr/node-staking/securing-your-node.mdx
@@ -570,15 +570,15 @@ sudo ufw allow "22/tcp" comment 'Allow SSH'
 Autorisez le client execution (anciennement appelé ETH1) :
 
 ```shell
-sudo ufw allow 30303/tcp comment 'Execution client port, standardized by Rocket Pool'
-sudo ufw allow 30303/udp comment 'Execution client port, standardized by Rocket Pool'
+sudo ufw allow 30303/tcp comment 'Execution client port, standardised by Rocket Pool'
+sudo ufw allow 30303/udp comment 'Execution client port, standardised by Rocket Pool'
 ```
 
 Autorisez le client consensus (anciennement appelé ETH2) :
 
 ```shell
-sudo ufw allow 9001/tcp comment 'Consensus client port, standardized by Rocket Pool'
-sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket Pool'
+sudo ufw allow 9001/tcp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 9001/udp comment 'Consensus client port, standardised by Rocket Pool'
 ```
 
 Si vous exécutez le client lighthouse v4.5.0+, vous pouvez utiliser le protocole quic pour réduire la latence / augmenter la bande passante, le protocole quic utilise le --port de lighthouse + 1 pour écouter les messages quic par défaut : https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html

--- a/docs/it/node-staking/securing-your-node.mdx
+++ b/docs/it/node-staking/securing-your-node.mdx
@@ -570,15 +570,15 @@ sudo ufw allow "22/tcp" comment 'Allow SSH'
 Permetti il client execution (precedentemente chiamato ETH1):
 
 ```shell
-sudo ufw allow 30303/tcp comment 'Execution client port, standardized by Rocket Pool'
-sudo ufw allow 30303/udp comment 'Execution client port, standardized by Rocket Pool'
+sudo ufw allow 30303/tcp comment 'Execution client port, standardised by Rocket Pool'
+sudo ufw allow 30303/udp comment 'Execution client port, standardised by Rocket Pool'
 ```
 
 Permetti il client consensus (precedentemente chiamato ETH2):
 
 ```shell
-sudo ufw allow 9001/tcp comment 'Consensus client port, standardized by Rocket Pool'
-sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket Pool'
+sudo ufw allow 9001/tcp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 9001/udp comment 'Consensus client port, standardised by Rocket Pool'
 ```
 
 Se esegui lighthouse client v4.5.0+, puoi usare il protocollo quic per ridurre la latenza / aumentare la larghezza di banda, il protocollo quic usa la --port di lighthouse + 1 per ascoltare i messaggi quic per impostazione predefinita: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html

--- a/docs/ja/node-staking/securing-your-node.mdx
+++ b/docs/ja/node-staking/securing-your-node.mdx
@@ -570,15 +570,15 @@ sudo ufw allow "22/tcp" comment 'Allow SSH'
 execution client（以前はETH1と呼ばれていました）を許可します。
 
 ```shell
-sudo ufw allow 30303/tcp comment 'Execution client port, standardized by Rocket Pool'
-sudo ufw allow 30303/udp comment 'Execution client port, standardized by Rocket Pool'
+sudo ufw allow 30303/tcp comment 'Execution client port, standardised by Rocket Pool'
+sudo ufw allow 30303/udp comment 'Execution client port, standardised by Rocket Pool'
 ```
 
 consensus client（以前はETH2と呼ばれていました）を許可します。
 
 ```shell
-sudo ufw allow 9001/tcp comment 'Consensus client port, standardized by Rocket Pool'
-sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket Pool'
+sudo ufw allow 9001/tcp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 9001/udp comment 'Consensus client port, standardised by Rocket Pool'
 ```
 
 lighthouse client v4.5.0+を実行している場合、quicプロトコルを使用してレイテンシを削減/帯域幅を増やすことができます。quicプロトコルはデフォルトでlighthouseの--port + 1を使用してquicメッセージをリッスンします: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html

--- a/docs/ko/node-staking/securing-your-node.mdx
+++ b/docs/ko/node-staking/securing-your-node.mdx
@@ -570,15 +570,15 @@ sudo ufw allow "22/tcp" comment 'Allow SSH'
 Execution 클라이언트 허용(이전에 ETH1이라고 불림):
 
 ```shell
-sudo ufw allow 30303/tcp comment 'Execution client port, standardized by Rocket Pool'
-sudo ufw allow 30303/udp comment 'Execution client port, standardized by Rocket Pool'
+sudo ufw allow 30303/tcp comment 'Execution client port, standardised by Rocket Pool'
+sudo ufw allow 30303/udp comment 'Execution client port, standardised by Rocket Pool'
 ```
 
 Consensus 클라이언트 허용(이전에 ETH2라고 불림):
 
 ```shell
-sudo ufw allow 9001/tcp comment 'Consensus client port, standardized by Rocket Pool'
-sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket Pool'
+sudo ufw allow 9001/tcp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 9001/udp comment 'Consensus client port, standardised by Rocket Pool'
 ```
 
 lighthouse 클라이언트 v4.5.0+를 실행하는 경우 quic 프로토콜을 사용하여 지연 시간을 줄이고/대역폭을 늘릴 수 있으며, quic 프로토콜은 기본적으로 lighthouse의 --port + 1을 사용하여 quic 메시지를 수신합니다: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html

--- a/docs/pt/node-staking/securing-your-node.mdx
+++ b/docs/pt/node-staking/securing-your-node.mdx
@@ -570,15 +570,15 @@ sudo ufw allow "22/tcp" comment 'Allow SSH'
 Permita cliente execution (anteriormente referido como ETH1):
 
 ```shell
-sudo ufw allow 30303/tcp comment 'Execution client port, standardized by Rocket Pool'
-sudo ufw allow 30303/udp comment 'Execution client port, standardized by Rocket Pool'
+sudo ufw allow 30303/tcp comment 'Execution client port, standardised by Rocket Pool'
+sudo ufw allow 30303/udp comment 'Execution client port, standardised by Rocket Pool'
 ```
 
 Permita cliente consensus (anteriormente referido como ETH2):
 
 ```shell
-sudo ufw allow 9001/tcp comment 'Consensus client port, standardized by Rocket Pool'
-sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket Pool'
+sudo ufw allow 9001/tcp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 9001/udp comment 'Consensus client port, standardised by Rocket Pool'
 ```
 
 Se você executar o cliente lighthouse v4.5.0+, você pode usar o protocolo quic para reduzir a latência / aumentar a largura de banda, o protocolo quic usa lighthouse's --port + 1 para escutar mensagens quic por padrão: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html

--- a/docs/ru/node-staking/securing-your-node.mdx
+++ b/docs/ru/node-staking/securing-your-node.mdx
@@ -570,15 +570,15 @@ sudo ufw allow "22/tcp" comment 'Allow SSH'
 Разрешите клиент execution (ранее именовавшийся как ETH1):
 
 ```shell
-sudo ufw allow 30303/tcp comment 'Execution client port, standardized by Rocket Pool'
-sudo ufw allow 30303/udp comment 'Execution client port, standardized by Rocket Pool'
+sudo ufw allow 30303/tcp comment 'Execution client port, standardised by Rocket Pool'
+sudo ufw allow 30303/udp comment 'Execution client port, standardised by Rocket Pool'
 ```
 
 Разрешите клиент consensus (ранее именовавшийся как ETH2):
 
 ```shell
-sudo ufw allow 9001/tcp comment 'Consensus client port, standardized by Rocket Pool'
-sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket Pool'
+sudo ufw allow 9001/tcp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 9001/udp comment 'Consensus client port, standardised by Rocket Pool'
 ```
 
 Если вы используете клиент lighthouse v4.5.0+, вы можете использовать протокол quic для уменьшения задержки / увеличения пропускной способности, протокол quic использует --port lighthouse + 1 для прослушивания сообщений quic по умолчанию: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html

--- a/docs/tr/node-staking/securing-your-node.mdx
+++ b/docs/tr/node-staking/securing-your-node.mdx
@@ -570,15 +570,15 @@ sudo ufw allow "22/tcp" comment 'Allow SSH'
 Execution istemcisine izin verin (eski adıyla ETH1):
 
 ```shell
-sudo ufw allow 30303/tcp comment 'Execution client port, standardized by Rocket Pool'
-sudo ufw allow 30303/udp comment 'Execution client port, standardized by Rocket Pool'
+sudo ufw allow 30303/tcp comment 'Execution client port, standardised by Rocket Pool'
+sudo ufw allow 30303/udp comment 'Execution client port, standardised by Rocket Pool'
 ```
 
 Consensus istemcisine izin verin (eski adıyla ETH2):
 
 ```shell
-sudo ufw allow 9001/tcp comment 'Consensus client port, standardized by Rocket Pool'
-sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket Pool'
+sudo ufw allow 9001/tcp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 9001/udp comment 'Consensus client port, standardised by Rocket Pool'
 ```
 
 Lighthouse istemci v4.5.0+ çalıştırıyorsanız, gecikmeyi azaltmak / bant genişliğini artırmak için quic protokolünü kullanabilirsiniz, quic protokolü varsayılan olarak lighthouse'un --port + 1'ini quic mesajlarını dinlemek için kullanır: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html

--- a/docs/zh/node-staking/securing-your-node.mdx
+++ b/docs/zh/node-staking/securing-your-node.mdx
@@ -570,15 +570,15 @@ sudo ufw allow "22/tcp" comment 'Allow SSH'
 允许执行客户端（以前称为 ETH1）：
 
 ```shell
-sudo ufw allow 30303/tcp comment 'Execution client port, standardized by Rocket Pool'
-sudo ufw allow 30303/udp comment 'Execution client port, standardized by Rocket Pool'
+sudo ufw allow 30303/tcp comment 'Execution client port, standardised by Rocket Pool'
+sudo ufw allow 30303/udp comment 'Execution client port, standardised by Rocket Pool'
 ```
 
 允许共识客户端（以前称为 ETH2）：
 
 ```shell
-sudo ufw allow 9001/tcp comment 'Consensus client port, standardized by Rocket Pool'
-sudo ufw allow 9001/udp comment 'Consensus client port, standardized by Rocket Pool'
+sudo ufw allow 9001/tcp comment 'Consensus client port, standardised by Rocket Pool'
+sudo ufw allow 9001/udp comment 'Consensus client port, standardised by Rocket Pool'
 ```
 
 如果你运行 lighthouse 客户端 v4.5.0+，你可以使用 quic 协议来减少延迟/增加带宽，quic 协议默认使用 lighthouse 的 --port + 1 来监听 quic 消息：https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html


### PR DESCRIPTION
In the documentation pages, there is inconsistency in the spelling of the suggested wording of the firewall rules. Some of the firewall rules use the British English spelling of the word "standardised" but on the very same page, 2 lines down, another rule uses the American English spelling "standardized". This inconsistency does not match the professionalism that the project would like to present. 

As an example, in the English language documentation (/docs/en/node-staking/securing-your-node.mdx): 

```
Allow execution client (formerly referred to as ETH1):
sudo ufw allow 30303/tcp comment 'Execution client port, **standardized** by Rocket Pool'
sudo ufw allow 30303/udp comment 'Execution client port, **standardized** by Rocket Pool'

Allow consensus client (formerly referred to as ETH2):
sudo ufw allow 9001/tcp comment 'Consensus client port, **standardized** by Rocket Pool'
sudo ufw allow 9001/udp comment 'Consensus client port, **standardized** by Rocket Pool'

If you run lighthouse client v4.5.0+, you can use quic protocol to reduce latency / increase bandwidth, quic protocol uses lighthouse's --port + 1 to listen for quic messages by default: https://lighthouse-blog.sigmaprime.io/Quic,%20Networking.html

sudo ufw allow 8001/udp comment 'Consensus client port, **standardised** by Rocket Pool'
```
