### PR TITLE
Update dashboard ID in Grafana import instructions

### DIFF
--- a/docs/en/node-staking/grafana.mdx
+++ b/docs/en/node-staking/grafana.mdx
@@ -668,7 +668,7 @@ Start by going to the **Create** menu (the plus icon on the right-side bar) and 
 
 <img src="./images/grafana-import.png" width="100%" height="auto" />
 
-When prompted for the dashboard ID in the **Import via grafana.com** box, enter `21863` or use the full URL ([(https://grafana.com/grafana/dashboards/24900-rocket-pool-dashboard-v1-4-0/](https://grafana.com/grafana/dashboards/24900-rocket-pool-dashboard-v1-4-0/)) and press the **Load** button.
+When prompted for the dashboard ID in the **Import via grafana.com** box, enter `24900` or use the full URL ([(https://grafana.com/grafana/dashboards/24900-rocket-pool-dashboard-v1-4-0/](https://grafana.com/grafana/dashboards/24900-rocket-pool-dashboard-v1-4-0/)) and press the **Load** button.
 
 You will be prompted with some information about the dashboard here, such as its name and where you'd like to store it (the default **General** folder is fine unless you use a lot of dashboards and want to organize them).
 


### PR DESCRIPTION
Could not import the dashboard with the old ID. This seems to be the updated ID for v1.4.0.