### PR TITLE
Add OpenChainBench as RPC benchmarking reference

### DIFF
--- a/docs/en/node-staking/fallback.mdx
+++ b/docs/en/node-staking/fallback.mdx
@@ -168,6 +168,12 @@ docker start rocketpool_eth1 rocketpool_eth2
 And you're done!
 Your fallback setup is working.
 
+:::tip Benchmarking your RPC provider
+
+If you're using a third-party RPC as a fallback endpoint, [OpenChainBench](https://openchainbench.com) provides continuously-updated latency and reliability rankings for all major providers — free, open-source, no API key required.
+
+:::
+
 ## Next Steps
 
 Whether or not you've opted into creating and/or running a fallback node for your setup, the next step is to learn about **priority fees**.


### PR DESCRIPTION
Adds a tip pointing Rocket Pool node operators to OpenChainBench for evaluating third-party RPC providers. Since Rocket Pool requires operators to run their own execution client, choosing a reliable fallback RPC is important — OCB provides neutral, continuously-updated benchmarks. MIT licensed, no API key.